### PR TITLE
Fixing duplicate issue

### DIFF
--- a/src/app/entry/pia.service.ts
+++ b/src/app/entry/pia.service.ts
@@ -191,13 +191,13 @@ export class PiaService {
       pia.status = 0;
       pia.created_at = null;
       pia.updated_at = null;
-      pia.dpos_names = null;
-      pia.dpo_status = null;
+      pia.dpos_names = 'N/A';
+      pia.dpo_status = 0;
       pia.dpo_opinion = null;
       pia.concerned_people_searched_opinion = null;
       pia.concerned_people_searched_content = null;
-      pia.people_names = null;
-      pia.concerned_people_status = null;
+      pia.people_names = 'N/A';
+      pia.concerned_people_status = 0;
       pia.concerned_people_opinion = null;
     } else {
       pia.status = parseInt(data.pia.status, 10);


### PR DESCRIPTION
Fixing issue https://github.com/pia-lab/pialab/issues/9

### Summary

Setting default values for the duplicated PIA that was not able to be persisted because of not nullable fields in backend entity (for those 4 fields : `pia.dpos_names`, `pia.dpo_status`, `pia.people_names` and `pia.concerned_people_status`.

The correct values seems to be setted after the first pia persisting action.
